### PR TITLE
Simplify ruff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,9 @@ select = ["ALL"]
 #   ISC001 Implicitly concatenated string literals on one line
 
 # Ignore other rules:
-#   ANN101 Missing type annotation for `self` in method
-#   ANN102 Missing type annotation for `cls` in classmethod
 #   D205 1 blank line required between summary line and description
 
-ignore = ["COM812", "ISC001", "ANN101", "ANN102", "D205"]
+ignore = ["COM812", "ISC001", "D205"]
 
 [tool.ruff.lint.per-file-ignores]
 # Ignore rules that aren't relevant in tests:


### PR DESCRIPTION
Don't need to ignore deprecated ruff rules as from 0.5.0