### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-poetry-package.yml
+++ b/.github/workflows/python-poetry-package.yml
@@ -2,6 +2,9 @@
 
 name: Python package with Poetry
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/elliot-100/Spond-classes/security/code-scanning/1](https://github.com/elliot-100/Spond-classes/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the current workflow. This ensures that the workflow has only the minimal permissions required to operate, reducing the risk of unintended actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
